### PR TITLE
Fix hiding of total hours when hours are completely removed

### DIFF
--- a/tdtimer.user.js
+++ b/tdtimer.user.js
@@ -98,6 +98,8 @@ function list_all_items() {
             }
 
             span.innerHTML = ""+total.toFixed(2)+"h";
+        } else if (header.lastChild.className == "tdtimer") {
+            header.removeChild(header.lastChild);
         }
     }
     setTimeout(list_all_items, 2000);


### PR DESCRIPTION
**Issue description**

When you have tasks filled with hours, header span shown with total hours number. That's OK.

But when you remove hours from tasks, it still shown.

**How to reproduce**

Create tasks:

```
Test task [1h]
Another task [2h]
```

On the top you will see 3.00h (that's OK). Now remove hours from tasks, so they will be:

```
Test task
Another task
```

Due to bug in code it still will leave 3.00h. **This branch fixes such issue**. Please merge it to master or discuss it with me.
